### PR TITLE
Preserve existing 'mode-line-misc-info

### DIFF
--- a/tablist.el
+++ b/tablist.el
@@ -313,14 +313,13 @@ as argument for the function `completion-in-region'.")
                                  mode-line-misc-info :key #'car-safe)))
     (cond
      ((not disable)
-      (set (make-local-variable 'mode-line-misc-info)
-           (append
-            (list
-             (list 'tablist-current-filter
-                   '(:eval (format " [%s]"
-                                   (if tablist-filter-suspended
-                                       "suspended"
-                                     "filtered")))))))
+      (make-local-variable 'mode-line-misc-info)
+      (push '(tablist-current-filter
+              (:eval (format " [%s]"
+                             (if tablist-filter-suspended
+                                 "suspended"
+                               "filtered"))))
+            mode-line-misc-info)
       (add-hook 'post-command-hook
                 'tablist-selection-changed-handler nil t)
       (add-hook 'tablist-selection-changed-functions


### PR DESCRIPTION
Without this, pre-existing `mode-line-misc-info' entries will not be shown.